### PR TITLE
add search by list of tags

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -372,7 +372,7 @@
             <td>reverse</td>
             <td>false</td>
             <td>true, false</td>
-            <td>rerverses the result list if set to true</td>
+            <td>reverses the result list if set to true</td>
           </tr>
           <tr>
             <td>hidebroken</td>
@@ -832,6 +832,12 @@
             <td>false</td>
             <td>true, false</td>
             <td>OPTIONAL. True: only exact matches, otherwise all matches.</td>
+          </tr>
+          <tr>
+            <td>tagList</td>
+            <td></td>
+            <td>STRING, STRING, ...</td>
+            <td>OPTIONAL. , a comma separated list of tag. It can also be an array of string in json HTTP POST parameters</td>
           </tr>
           <tr>
             <td>bitrateMin</td>

--- a/index.php
+++ b/index.php
@@ -62,6 +62,7 @@ if (isset($_GET['action'])) {
     $languageExact = convertToBool(getParameter('languageExact', 'false'));
     $tags = getParameter('tags', null);
     $tag = getParameter('tag', null);
+    $tagList = getParameter('tagList', null);
     $tagExact = convertToBool(getParameter('tagExact', 'false'));
 
     if ($action == 'tags') {
@@ -78,7 +79,7 @@ if (isset($_GET['action'])) {
     }elseif ($action == 'stats') {
         print_stats($db, $format);
     }elseif ($action == 'data_search_advanced') {
-        print_stations_list_data_advanced($db, $format, $name, $nameExact, $country, $countryExact, $state, $stateExact, $language, $languageExact, $tag, $tagExact, $bitrateMin, $bitrateMax, $order, $reverse, $hideBroken, $offset, $limit);
+        print_stations_list_data_advanced($db, $format, $name, $nameExact, $country, $countryExact, $state, $stateExact, $language, $languageExact, $tag, $tagExact, $tagList, $bitrateMin, $bitrateMax, $order, $reverse, $hideBroken, $offset, $limit);
     }elseif ($action == 'data_search_topvote') {
         print_stations_list_data_all($db, $format, "votes", "true", $offset, $limit);
     }elseif ($action == 'data_search_topclick') {


### PR DESCRIPTION
Allows the user to search stations based on multiple tag list.
This list can be a coma separated tag list string.
It can also be an array of string in json HTTP POST parameters

Signed-off-by: Julien Ledun <j.ledun@iosystems.fr>